### PR TITLE
Тост создания рецепта

### DIFF
--- a/src/config/static/js/recipes.js
+++ b/src/config/static/js/recipes.js
@@ -102,6 +102,7 @@ async function saveRecipe(event) {
     const form = event.target;
     const rows = document.querySelectorAll('.ingredient-row');
     const recipeIngredients = [];
+    const isEditing = Boolean(editingRecipeId);
 
     rows.forEach(row => {
         const ingredientId = row.querySelector('.ingredient-select').value;
@@ -124,12 +125,12 @@ async function saveRecipe(event) {
     };
 
     try {
-        if (editingRecipeId) {
+        if (isEditing) {
             await apiFetch(`/api/recipes/${editingRecipeId}/`, { method: 'PUT', body });
         } else {
             await apiFetch('/api/recipes/', { method: 'POST', body });
         }
-        showError('Рецепт успешно сохранён!');
+        showToast(isEditing ? 'Рецепт обновлён' : 'Рецепт создан');
         clearRecipeForm();
         editingRecipeId = null;
         recipes = await apiFetch('/api/recipes/');


### PR DESCRIPTION
Add a toast notification after saving a recipe to provide user feedback.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-178d5952-8fae-40cf-8565-8915cee17ce7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-178d5952-8fae-40cf-8565-8915cee17ce7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI feedback change limited to the recipe save flow; no changes to API calls, data handling, or permissions.
> 
> **Overview**
> After saving a recipe in `recipes.js`, the success feedback is switched from `showError('Рецепт успешно сохранён!')` (alert) to `showToast(...)`, showing **different messages for create vs update**.
> 
> The save handler now derives an `isEditing` flag once from `editingRecipeId` and uses it both to choose `POST` vs `PUT` and to select the toast message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 695eaca8c9290c412aafd327dc811325bb8d3063. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->