### PR TITLE
Migration pending trigger events

### DIFF
--- a/src/planner/migrations/0004_add_menu_model.py
+++ b/src/planner/migrations/0004_add_menu_model.py
@@ -1,4 +1,4 @@
-"""Add Menu model and migrate MenuSlot from user FK to menu FK."""
+"""Add Menu model, nullable FK on MenuSlot, and migrate existing data."""
 
 import django.db.models.deletion
 from django.conf import settings
@@ -69,33 +69,5 @@ class Migration(migrations.Migration):
         migrations.RunPython(
             create_menus_for_existing_users,
             migrations.RunPython.noop,
-        ),
-        migrations.RemoveConstraint(
-            model_name="menuslot",
-            name="unique_user_day_meal",
-        ),
-        migrations.RemoveField(
-            model_name="menuslot",
-            name="user",
-        ),
-        migrations.AlterField(
-            model_name="menuslot",
-            name="menu",
-            field=models.ForeignKey(
-                on_delete=django.db.models.deletion.CASCADE,
-                related_name="slots",
-                to="planner.menu",
-            ),
-        ),
-        migrations.AlterModelOptions(
-            name="menuslot",
-            options={"ordering": ["menu", "day_of_week", "meal_type"]},
-        ),
-        migrations.AddConstraint(
-            model_name="menuslot",
-            constraint=models.UniqueConstraint(
-                fields=("menu", "day_of_week", "meal_type"),
-                name="unique_menu_day_meal",
-            ),
         ),
     ]

--- a/src/planner/migrations/0005_menuslot_replace_user_with_menu.py
+++ b/src/planner/migrations/0005_menuslot_replace_user_with_menu.py
@@ -1,0 +1,41 @@
+"""Replace MenuSlot.user FK with non-nullable MenuSlot.menu FK."""
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("planner", "0004_add_menu_model"),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name="menuslot",
+            name="unique_user_day_meal",
+        ),
+        migrations.RemoveField(
+            model_name="menuslot",
+            name="user",
+        ),
+        migrations.AlterField(
+            model_name="menuslot",
+            name="menu",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="slots",
+                to="planner.menu",
+            ),
+        ),
+        migrations.AlterModelOptions(
+            name="menuslot",
+            options={"ordering": ["menu", "day_of_week", "meal_type"]},
+        ),
+        migrations.AddConstraint(
+            model_name="menuslot",
+            constraint=models.UniqueConstraint(
+                fields=("menu", "day_of_week", "meal_type"),
+                name="unique_menu_day_meal",
+            ),
+        ),
+    ]


### PR DESCRIPTION
Split Django migration `0004_add_menu_model` into two to resolve a PostgreSQL `OperationalError` during `ALTER TABLE` operations.

The original migration attempted both data modifications (updating `MenuSlot` rows) and schema changes (`ALTER TABLE` to remove/add constraints and fields) on the `MenuSlot` table within a single transaction. PostgreSQL disallows `ALTER TABLE` on a table with pending trigger events from data modifications in the same transaction. The split ensures data migration and schema changes occur in separate transactions, resolving the error.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-e0377bec-c87c-47d1-9351-2efd50a50928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e0377bec-c87c-47d1-9351-2efd50a50928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

