### PR TITLE
Импорт по ссылке антибот

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "gunicorn>=25.0.1",
     "psycopg[binary]>=3.3.2",
     "python-dotenv>=1.2.1",
-    "selenium>=4.40.0",
 ]
 
 [dependency-groups]

--- a/src/config/static/js/ingredients.js
+++ b/src/config/static/js/ingredients.js
@@ -1,5 +1,9 @@
 /**
  * Ingredient CRUD, rendering, filtering, and import from external URLs.
+ *
+ * Import flow: the browser fetches the product page directly (bypassing
+ * anti-bot protection as a real client). If CORS blocks the request,
+ * a fallback textarea is shown for manual HTML paste.
  */
 
 async function importIngredientFromUrl(event) {
@@ -14,20 +18,84 @@ async function importIngredientFromUrl(event) {
     btn.textContent = '⏳ Загрузка...';
 
     try {
-        await apiFetch('/api/ingredients/import-url/', {
-            method: 'POST',
-            body: { url }
-        });
-        ingredients = await apiFetch('/api/ingredients/');
-        form.reset();
-        renderIngredients();
-        showToast('Ингредиент успешно импортирован!');
+        const html = await _fetchPageHtml(url);
+        if (html) {
+            await _submitImport(url, html, form);
+        } else {
+            _showHtmlFallback(url);
+        }
     } catch (e) {
         showError(e.message || 'Ошибка импорта ингредиента');
     } finally {
         btn.disabled = false;
         btn.textContent = originalText;
     }
+}
+
+async function importIngredientFromHtml(event) {
+    event.preventDefault();
+    const url = document.getElementById('importFallbackUrl').value;
+    const html = document.getElementById('importHtmlInput').value.trim();
+    if (!html) {
+        showError('Вставьте содержимое страницы');
+        return;
+    }
+
+    const btn = document.getElementById('importHtmlBtn');
+    const originalText = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = '⏳ Загрузка...';
+
+    try {
+        await _submitImport(url, html, document.getElementById('importIngredientForm'));
+        _hideHtmlFallback();
+    } catch (e) {
+        showError(e.message || 'Ошибка импорта ингредиента');
+    } finally {
+        btn.disabled = false;
+        btn.textContent = originalText;
+    }
+}
+
+async function _fetchPageHtml(url) {
+    try {
+        const resp = await fetch(url, {
+            mode: 'cors',
+            credentials: 'omit',
+        });
+        if (resp.ok) {
+            return await resp.text();
+        }
+    } catch (_ignored) { /* CORS or network error — use fallback */ }
+    return null;
+}
+
+async function _submitImport(url, html, form) {
+    await apiFetch('/api/ingredients/import-url/', {
+        method: 'POST',
+        body: { url, html }
+    });
+    ingredients = await apiFetch('/api/ingredients/');
+    form.reset();
+    renderIngredients();
+    showToast('Ингредиент успешно импортирован!');
+}
+
+function _showHtmlFallback(url) {
+    document.getElementById('importFallbackUrl').value = url;
+    document.getElementById('importHtmlFallback').style.display = 'block';
+    document.getElementById('importHtmlInput').value = '';
+    document.getElementById('importHtmlInput').focus();
+}
+
+function _hideHtmlFallback() {
+    document.getElementById('importHtmlFallback').style.display = 'none';
+    document.getElementById('importHtmlInput').value = '';
+}
+
+function openImportUrl() {
+    const url = document.getElementById('importFallbackUrl').value;
+    if (url) window.open(url, '_blank');
 }
 
 async function saveIngredient(event) {

--- a/src/config/templates/recipe_manager/_tab_ingredients.html
+++ b/src/config/templates/recipe_manager/_tab_ingredients.html
@@ -14,6 +14,26 @@
                     <button type="submit" class="btn btn-primary btn-import" id="importBtn">📥 Импорт</button>
                 </div>
             </form>
+
+            <div id="importHtmlFallback" style="display: none; margin-top: 1rem;">
+                <input type="hidden" id="importFallbackUrl">
+                <p class="text-muted" style="margin-bottom: 0.5rem;">
+                    Не удалось загрузить страницу автоматически.
+                    Откройте ссылку, скопируйте исходный код страницы
+                    (Ctrl+U &rarr; Ctrl+A &rarr; Ctrl+C) и вставьте сюда:
+                </p>
+                <div style="display: flex; gap: 0.5rem; margin-bottom: 0.5rem;">
+                    <button type="button" class="btn btn-secondary" onclick="openImportUrl()">🔗 Открыть ссылку</button>
+                </div>
+                <form onsubmit="importIngredientFromHtml(event)">
+                    <div class="form-group">
+                        <textarea id="importHtmlInput" rows="6"
+                                  placeholder="Вставьте исходный код страницы сюда..."
+                                  style="width: 100%; font-family: monospace; font-size: 0.85rem;"></textarea>
+                    </div>
+                    <button type="submit" class="btn btn-primary" id="importHtmlBtn">📥 Импортировать из вставленного кода</button>
+                </form>
+            </div>
         </div>
 
         <div class="ingredient-form-section">

--- a/src/planner/services_import.py
+++ b/src/planner/services_import.py
@@ -1,16 +1,14 @@
-"""Service for importing ingredients from external store URLs (e.g. 5ka.ru)."""
+"""Service for importing ingredients from external store URLs (e.g. 5ka.ru).
+
+The HTML content is expected to be fetched by the user's browser (client-side)
+and sent to the server for parsing, bypassing anti-bot protections.
+"""
 
 import logging
-import os
 import re
 from dataclasses import dataclass
 
 from bs4 import BeautifulSoup
-from selenium import webdriver
-from selenium.webdriver.chrome.service import Service as ChromeService
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import WebDriverWait
 
 logger = logging.getLogger(__name__)
 
@@ -23,9 +21,6 @@ PYATEROCHKA_URL_PATTERN_ALT = re.compile(
     r"https?://(?:www\.)?5ka\.ru/product/(?P<plu>\d+)/(?P<slug>[a-z0-9-]+?)/?",
     re.IGNORECASE,
 )
-
-SELENIUM_PAGE_LOAD_TIMEOUT = 15
-SELENIUM_BODY_WAIT_TIMEOUT = 15
 
 
 class IngredientImportError(Exception):
@@ -43,13 +38,14 @@ class ParsedIngredient:
     carbs: float
 
 
-def import_ingredient_from_url(url: str) -> ParsedIngredient:
-    """Import ingredient data from a supported store URL.
+def import_ingredient(url: str, html: str) -> ParsedIngredient:
+    """Import ingredient data from HTML fetched by the user's browser.
 
-    Currently supports 5ka.ru product pages.
+    Validates the URL to extract the product PLU, then parses
+    the provided HTML content. Currently supports 5ka.ru product pages.
     """
-    validated_url, plu = _extract_plu_from_url(url)
-    return _fetch_and_parse_product(validated_url, plu)
+    _validated_url, plu = _extract_plu_from_url(url)
+    return _parse_product_page(html, plu)
 
 
 def _extract_plu_from_url(url: str) -> tuple[str, str]:
@@ -73,67 +69,6 @@ def _extract_plu_from_url(url: str) -> tuple[str, str]:
         "Неподдерживаемый формат ссылки. "
         "Поддерживаются ссылки вида: https://5ka.ru/product/название--123456/"
     )
-
-
-def _fetch_and_parse_product(url: str, plu: str) -> ParsedIngredient:
-    """Fetch product page and extract ingredient data."""
-    try:
-        html = _fetch_page(url)
-    except IngredientImportError:
-        raise
-    except Exception as exc:
-        logger.warning("Failed to fetch %s: %s", url, exc)
-        raise IngredientImportError(
-            "Не удалось загрузить страницу. Проверьте ссылку и попробуйте снова."
-        ) from exc
-
-    return _parse_product_page(html, plu)
-
-
-def _fetch_page(url: str) -> str:
-    """Fetch page content using a local headless Chrome via Selenium.
-
-    Launches a headless Chromium process to render the page,
-    bypassing anti-bot protection that blocks plain HTTP requests.
-    """
-    driver = _create_webdriver()
-    try:
-        driver.set_page_load_timeout(SELENIUM_PAGE_LOAD_TIMEOUT)
-        driver.get(url)
-        WebDriverWait(driver, SELENIUM_BODY_WAIT_TIMEOUT).until(
-            EC.presence_of_element_located((By.TAG_NAME, "body"))
-        )
-        return driver.page_source
-    finally:
-        driver.quit()
-
-
-def _create_webdriver() -> webdriver.Chrome:
-    """Create a local headless Chrome WebDriver instance."""
-    options = webdriver.ChromeOptions()
-    options.add_argument("--headless=new")
-    options.add_argument("--no-sandbox")
-    options.add_argument("--disable-dev-shm-usage")
-    options.add_argument("--disable-gpu")
-    options.add_argument("--window-size=1920,1080")
-    options.add_argument("--lang=ru-RU")
-    options.add_argument(
-        "--user-agent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-    )
-
-    chrome_bin = os.environ.get("CHROME_BIN")
-    if chrome_bin:
-        options.binary_location = chrome_bin
-
-    chromedriver_path = os.environ.get("CHROMEDRIVER_PATH")
-    service = (
-        ChromeService(executable_path=chromedriver_path)
-        if chromedriver_path
-        else ChromeService()
-    )
-
-    return webdriver.Chrome(service=service, options=options)
 
 
 def _parse_product_page(html: str, plu: str) -> ParsedIngredient:

--- a/src/planner/tests_import.py
+++ b/src/planner/tests_import.py
@@ -1,7 +1,6 @@
 """Tests for ingredient import from external URLs (5ka.ru)."""
 
 import json
-from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
@@ -13,7 +12,7 @@ from planner.services_import import (
     _is_antibot_page,
     _parse_nutrition_from_text,
     _parse_product_page,
-    import_ingredient_from_url,
+    import_ingredient,
 )
 
 User = get_user_model()
@@ -302,14 +301,13 @@ class IsAntibotPageTests(TestCase):
         self.assertFalse(_is_antibot_page(SAMPLE_HTML_WITH_JSON_LD))
 
 
-class ImportIngredientFromUrlTests(TestCase):
-    """Test the full import flow with mocked HTTP responses."""
+class ImportIngredientTests(TestCase):
+    """Test the full import flow with client-provided HTML."""
 
-    @patch("planner.services_import._fetch_page")
-    def test_successful_import_json_ld(self, mock_fetch):
-        mock_fetch.return_value = SAMPLE_HTML_WITH_JSON_LD
-        result = import_ingredient_from_url(
-            "https://5ka.ru/product/makarony-barilla-lazanya-500g--3020941/"
+    def test_successful_import_json_ld(self):
+        result = import_ingredient(
+            "https://5ka.ru/product/makarony-barilla-lazanya-500g--3020941/",
+            SAMPLE_HTML_WITH_JSON_LD,
         )
         self.assertEqual(result.name, "Макароны Barilla Лазанья")
         self.assertEqual(result.calories, 359)
@@ -317,26 +315,27 @@ class ImportIngredientFromUrlTests(TestCase):
         self.assertEqual(result.fat, 2)
         self.assertEqual(result.carbs, 69.7)
 
-    @patch("planner.services_import._fetch_page")
-    def test_successful_import_next_data(self, mock_fetch):
-        mock_fetch.return_value = SAMPLE_HTML_WITH_NEXT_DATA
-        result = import_ingredient_from_url(
-            "https://5ka.ru/product/moloko-prostokvashino--2085981/"
+    def test_successful_import_next_data(self):
+        result = import_ingredient(
+            "https://5ka.ru/product/moloko-prostokvashino--2085981/",
+            SAMPLE_HTML_WITH_NEXT_DATA,
         )
         self.assertEqual(result.name, "Молоко Простоквашино 3.2%")
         self.assertEqual(result.calories, 58)
 
-    @patch("planner.services_import._fetch_page")
-    def test_antibot_raises_import_error(self, mock_fetch):
-        mock_fetch.return_value = SAMPLE_HTML_ANTIBOT
+    def test_antibot_raises_import_error(self):
         with self.assertRaises(IngredientImportError):
-            import_ingredient_from_url(
-                "https://5ka.ru/product/makarony-barilla-lazanya-500g--3020941/"
+            import_ingredient(
+                "https://5ka.ru/product/makarony-barilla-lazanya-500g--3020941/",
+                SAMPLE_HTML_ANTIBOT,
             )
 
     def test_invalid_url_raises_import_error(self):
         with self.assertRaises(IngredientImportError):
-            import_ingredient_from_url("https://example.com/product/123")
+            import_ingredient(
+                "https://example.com/product/123",
+                SAMPLE_HTML_WITH_JSON_LD,
+            )
 
 
 class IngredientImportApiTests(TestCase):
@@ -349,14 +348,13 @@ class IngredientImportApiTests(TestCase):
         )
         self.client.force_login(self.user)
 
-    @patch("planner.services_import._fetch_page")
-    def test_import_creates_ingredient(self, mock_fetch):
-        mock_fetch.return_value = SAMPLE_HTML_WITH_JSON_LD
+    def test_import_creates_ingredient(self):
         response = self.client.post(
             "/api/ingredients/import-url/",
-            data=json.dumps(
-                {"url": "https://5ka.ru/product/makarony-barilla-lazanya-500g--3020941/"}
-            ),
+            data=json.dumps({
+                "url": "https://5ka.ru/product/makarony-barilla-lazanya-500g--3020941/",
+                "html": SAMPLE_HTML_WITH_JSON_LD,
+            }),
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 201)
@@ -376,7 +374,7 @@ class IngredientImportApiTests(TestCase):
     def test_import_empty_url_returns_400(self):
         response = self.client.post(
             "/api/ingredients/import-url/",
-            data=json.dumps({"url": ""}),
+            data=json.dumps({"url": "", "html": "<html></html>"}),
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 400)
@@ -385,7 +383,18 @@ class IngredientImportApiTests(TestCase):
     def test_import_missing_url_returns_400(self):
         response = self.client.post(
             "/api/ingredients/import-url/",
-            data=json.dumps({}),
+            data=json.dumps({"html": "<html></html>"}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("error", response.json())
+
+    def test_import_missing_html_returns_400(self):
+        response = self.client.post(
+            "/api/ingredients/import-url/",
+            data=json.dumps({
+                "url": "https://5ka.ru/product/makarony-barilla-lazanya-500g--3020941/",
+            }),
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 400)
@@ -394,29 +403,29 @@ class IngredientImportApiTests(TestCase):
     def test_import_invalid_url_returns_400(self):
         response = self.client.post(
             "/api/ingredients/import-url/",
-            data=json.dumps({"url": "https://example.com/product/123"}),
+            data=json.dumps({
+                "url": "https://example.com/product/123",
+                "html": SAMPLE_HTML_WITH_JSON_LD,
+            }),
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn("error", response.json())
 
-    @patch("planner.services_import._fetch_page")
-    def test_import_antibot_returns_400(self, mock_fetch):
-        mock_fetch.return_value = SAMPLE_HTML_ANTIBOT
+    def test_import_antibot_returns_400(self):
         response = self.client.post(
             "/api/ingredients/import-url/",
-            data=json.dumps(
-                {"url": "https://5ka.ru/product/makarony-barilla-lazanya-500g--3020941/"}
-            ),
+            data=json.dumps({
+                "url": "https://5ka.ru/product/makarony-barilla-lazanya-500g--3020941/",
+                "html": SAMPLE_HTML_ANTIBOT,
+            }),
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn("error", response.json())
         self.assertIn("антибот", response.json()["error"])
 
-    @patch("planner.services_import._fetch_page")
-    def test_import_duplicate_ingredient_returns_400(self, mock_fetch):
-        mock_fetch.return_value = SAMPLE_HTML_WITH_JSON_LD
+    def test_import_duplicate_ingredient_returns_400(self):
         Ingredient.objects.create(
             user=self.user,
             name="Макароны Barilla Лазанья",
@@ -424,9 +433,10 @@ class IngredientImportApiTests(TestCase):
         )
         response = self.client.post(
             "/api/ingredients/import-url/",
-            data=json.dumps(
-                {"url": "https://5ka.ru/product/makarony-barilla-lazanya-500g--3020941/"}
-            ),
+            data=json.dumps({
+                "url": "https://5ka.ru/product/makarony-barilla-lazanya-500g--3020941/",
+                "html": SAMPLE_HTML_WITH_JSON_LD,
+            }),
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 400)
@@ -435,9 +445,10 @@ class IngredientImportApiTests(TestCase):
         anon_client = Client()
         response = anon_client.post(
             "/api/ingredients/import-url/",
-            data=json.dumps(
-                {"url": "https://5ka.ru/product/makarony-barilla-lazanya-500g--3020941/"}
-            ),
+            data=json.dumps({
+                "url": "https://5ka.ru/product/makarony-barilla-lazanya-500g--3020941/",
+                "html": SAMPLE_HTML_WITH_JSON_LD,
+            }),
             content_type="application/json",
         )
         self.assertIn(response.status_code, [401, 403])

--- a/src/planner/views_api.py
+++ b/src/planner/views_api.py
@@ -27,7 +27,7 @@ from planner.services import (
     get_or_create_first_menu,
 )
 from planner.services_friends import get_editable_owner_ids
-from planner.services_import import IngredientImportError, import_ingredient_from_url
+from planner.services_import import IngredientImportError, import_ingredient
 
 logger = logging.getLogger(__name__)
 
@@ -86,18 +86,30 @@ class IngredientViewSet(viewsets.ModelViewSet):
 
 
 class IngredientImportView(APIView):
-    """Import an ingredient from an external store URL (e.g. 5ka.ru)."""
+    """Import an ingredient from HTML fetched by the user's browser.
+
+    Expects ``url`` (for validation/PLU extraction) and ``html``
+    (page source fetched client-side) in the request body.
+    """
 
     def post(self, request):
-        url = (request.data or {}).get("url", "").strip()
+        data = request.data or {}
+        url = data.get("url", "").strip()
+        html = data.get("html", "").strip()
+
         if not url:
             return Response(
                 {"error": "Укажите ссылку на продукт"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+        if not html:
+            return Response(
+                {"error": "Отсутствует HTML-содержимое страницы"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         try:
-            parsed = _parse_ingredient_from_url(url)
+            parsed = _parse_ingredient_from_html(url, html)
         except IngredientImportError as exc:
             return Response(
                 {"error": str(exc)},
@@ -278,10 +290,10 @@ class ShoppingListView(APIView):
         return Response(result)
 
 
-def _parse_ingredient_from_url(url):
-    """Call import service and handle errors, returning parsed data or None."""
+def _parse_ingredient_from_html(url, html):
+    """Call import service with client-provided HTML, returning parsed data or None."""
     try:
-        return import_ingredient_from_url(url)
+        return import_ingredient(url, html)
     except IngredientImportError:
         raise
     except Exception:

--- a/uv.lock
+++ b/uv.lock
@@ -12,24 +12,6 @@ wheels = [
 ]
 
 [[package]]
-name = "async-generator"
-version = "1.10"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/b6/6fa6b3b598a03cba5e80f829e0dadbb49d7645f523d209b2fb7ea0bbb02a/async_generator-1.10.tar.gz", hash = "sha256:6ebb3d106c12920aaae42ccb6f787ef5eefdcdd166ea3d628fa8476abe712144", size = 29870, upload-time = "2018-08-01T03:36:21.69Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/52/39d20e03abd0ac9159c162ec24b93fbcaa111e8400308f2465432495ca2b/async_generator-1.10-py3-none-any.whl", hash = "sha256:01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b", size = 18857, upload-time = "2018-08-01T03:36:20.029Z" },
-]
-
-[[package]]
-name = "attrs"
-version = "25.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
-]
-
-[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -40,35 +22,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
-]
-
-[[package]]
-name = "certifi"
-version = "2026.1.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
-]
-
-[[package]]
-name = "cffi"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
-    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -186,7 +139,6 @@ dependencies = [
     { name = "gunicorn" },
     { name = "psycopg", extra = ["binary"] },
     { name = "python-dotenv" },
-    { name = "selenium" },
 ]
 
 [package.dev-dependencies]
@@ -208,7 +160,6 @@ requires-dist = [
     { name = "gunicorn", specifier = ">=25.0.1" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.2" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
-    { name = "selenium", specifier = ">=4.40.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -235,42 +186,12 @@ wheels = [
 ]
 
 [[package]]
-name = "h11"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
-]
-
-[[package]]
 name = "identify"
 version = "2.6.16"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5b/8d/e8b97e6bd3fb6fb271346f7981362f1e04d6a7463abd0de79e1fda17c067/identify-2.6.16.tar.gz", hash = "sha256:846857203b5511bbe94d5a352a48ef2359532bc8f6727b5544077a0dcfb24980", size = 99360, upload-time = "2026-01-12T18:58:58.201Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/58/40fbbcefeda82364720eba5cf2270f98496bdfa19ea75b4cccae79c698e6/identify-2.6.16-py2.py3-none-any.whl", hash = "sha256:391ee4d77741d994189522896270b787aed8670389bfd60f326d677d64a6dfb0", size = 99202, upload-time = "2026-01-12T18:58:56.627Z" },
-]
-
-[[package]]
-name = "idna"
-version = "3.11"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
-]
-
-[[package]]
-name = "importlib-metadata"
-version = "8.7.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
 ]
 
 [[package]]
@@ -366,18 +287,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
-]
-
-[[package]]
-name = "outcome"
-version = "1.3.0.post0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/98/df/77698abfac98571e65ffeb0c1fba8ffd692ab8458d617a0eed7d9a8d38f2/outcome-1.3.0.post0.tar.gz", hash = "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8", size = 21060, upload-time = "2023-10-26T04:26:04.361Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/8b/5ab7257531a5d830fc8000c476e63c935488d74609b50f9384a643ec0a62/outcome-1.3.0.post0-py2.py3-none-any.whl", hash = "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b", size = 10692, upload-time = "2023-10-26T04:26:02.532Z" },
 ]
 
 [[package]]
@@ -479,30 +388,12 @@ wheels = [
 ]
 
 [[package]]
-name = "pycparser"
-version = "3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
-]
-
-[[package]]
-name = "pysocks"
-version = "1.7.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
 ]
 
 [[package]]
@@ -604,44 +495,6 @@ wheels = [
 ]
 
 [[package]]
-name = "selenium"
-version = "4.40.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "trio" },
-    { name = "trio-typing" },
-    { name = "trio-websocket" },
-    { name = "types-certifi" },
-    { name = "types-urllib3" },
-    { name = "typing-extensions" },
-    { name = "urllib3", extra = ["socks"] },
-    { name = "websocket-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/ef/a5727fa7b33d20d296322adf851b76072d8d3513e1b151969d3228437faf/selenium-4.40.0.tar.gz", hash = "sha256:a88f5905d88ad0b84991c2386ea39e2bbde6d6c334be38df5842318ba98eaa8c", size = 930444, upload-time = "2026-01-18T23:12:31.565Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/74/eb9d6540aca1911106fa0877b8e9ef24171bc18857937a6b0ffe0586c623/selenium-4.40.0-py3-none-any.whl", hash = "sha256:c8823fc02e2c771d9ad9a0cf899cee7de1a57a6697e3d0b91f67566129f2b729", size = 9608184, upload-time = "2026-01-18T23:12:29.435Z" },
-]
-
-[[package]]
-name = "sniffio"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
-]
-
-[[package]]
-name = "sortedcontainers"
-version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
-]
-
-[[package]]
 name = "soupsieve"
 version = "2.8.3"
 source = { registry = "https://pypi.org/simple" }
@@ -660,78 +513,12 @@ wheels = [
 ]
 
 [[package]]
-name = "trio"
-version = "0.32.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "cffi", marker = "implementation_name != 'pypy' and os_name == 'nt'" },
-    { name = "idna" },
-    { name = "outcome" },
-    { name = "sniffio" },
-    { name = "sortedcontainers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/ce/0041ddd9160aac0031bcf5ab786c7640d795c797e67c438e15cfedf815c8/trio-0.32.0.tar.gz", hash = "sha256:150f29ec923bcd51231e1d4c71c7006e65247d68759dd1c19af4ea815a25806b", size = 605323, upload-time = "2025-10-31T07:18:17.466Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/bf/945d527ff706233636c73880b22c7c953f3faeb9d6c7e2e85bfbfd0134a0/trio-0.32.0-py3-none-any.whl", hash = "sha256:4ab65984ef8370b79a76659ec87aa3a30c5c7c83ff250b4de88c29a8ab6123c5", size = 512030, upload-time = "2025-10-31T07:18:15.885Z" },
-]
-
-[[package]]
-name = "trio-typing"
-version = "0.10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "async-generator" },
-    { name = "importlib-metadata" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "trio" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/74/a87aafa40ec3a37089148b859892cbe2eef08d132c816d58a60459be5337/trio-typing-0.10.0.tar.gz", hash = "sha256:065ee684296d52a8ab0e2374666301aec36ee5747ac0e7a61f230250f8907ac3", size = 38747, upload-time = "2023-12-01T02:54:55.508Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/ff/9bd795273eb14fac7f6a59d16cc8c4d0948a619a1193d375437c7f50f3eb/trio_typing-0.10.0-py3-none-any.whl", hash = "sha256:6d0e7ec9d837a2fe03591031a172533fbf4a1a95baf369edebfc51d5a49f0264", size = 42224, upload-time = "2023-12-01T02:54:54.1Z" },
-]
-
-[[package]]
-name = "trio-websocket"
-version = "0.12.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "outcome" },
-    { name = "trio" },
-    { name = "wsproto" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/3c/8b4358e81f2f2cfe71b66a267f023a91db20a817b9425dd964873796980a/trio_websocket-0.12.2.tar.gz", hash = "sha256:22c72c436f3d1e264d0910a3951934798dcc5b00ae56fc4ee079d46c7cf20fae", size = 33549, upload-time = "2025-02-25T05:16:58.947Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/19/eb640a397bba49ba49ef9dbe2e7e5c04202ba045b6ce2ec36e9cadc51e04/trio_websocket-0.12.2-py3-none-any.whl", hash = "sha256:df605665f1db533f4a386c94525870851096a223adcb97f72a07e8b4beba45b6", size = 21221, upload-time = "2025-02-25T05:16:57.545Z" },
-]
-
-[[package]]
-name = "types-certifi"
-version = "2021.10.8.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/68/943c3aeaf14624712a0357c4a67814dba5cea36d194f5c764dad7959a00c/types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f", size = 2095, upload-time = "2022-06-09T15:19:05.244Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/63/2463d89481e811f007b0e1cd0a91e52e141b47f9de724d20db7b861dcfec/types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a", size = 2136, upload-time = "2022-06-09T15:19:03.127Z" },
-]
-
-[[package]]
 name = "types-pyyaml"
 version = "6.0.12.20250915"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
-]
-
-[[package]]
-name = "types-urllib3"
-version = "1.26.25.14"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/de/b9d7a68ad39092368fb21dd6194b362b98a1daeea5dcfef5e1adb5031c7e/types-urllib3-1.26.25.14.tar.gz", hash = "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f", size = 11239, upload-time = "2023-07-20T15:19:31.307Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/7b/3fc711b2efea5e85a7a0bbfe269ea944aa767bbba5ec52f9ee45d362ccf3/types_urllib3-1.26.25.14-py3-none-any.whl", hash = "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e", size = 15377, upload-time = "2023-07-20T15:19:30.379Z" },
 ]
 
 [[package]]
@@ -753,20 +540,6 @@ wheels = [
 ]
 
 [[package]]
-name = "urllib3"
-version = "2.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
-]
-
-[package.optional-dependencies]
-socks = [
-    { name = "pysocks" },
-]
-
-[[package]]
 name = "virtualenv"
 version = "20.36.1"
 source = { registry = "https://pypi.org/simple" }
@@ -778,34 +551,4 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/2a/dc2228b2888f51192c7dc766106cd475f1b768c10caaf9727659726f7391/virtualenv-20.36.1-py3-none-any.whl", hash = "sha256:575a8d6b124ef88f6f51d56d656132389f961062a9177016a50e4f507bbcc19f", size = 6008258, upload-time = "2026-01-09T18:20:59.425Z" },
-]
-
-[[package]]
-name = "websocket-client"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
-]
-
-[[package]]
-name = "wsproto"
-version = "1.3.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "3.23.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]


### PR DESCRIPTION
Replaced server-side Selenium with client-side fetching for ingredient import to bypass anti-bot protection.

The previous Selenium-based approach for importing ingredients from sites like 5ka.ru was consistently blocked by anti-bot systems. This PR shifts the page fetching responsibility to the user's browser, which is seen as a legitimate client, and then sends the raw HTML to the backend for parsing. A manual HTML paste fallback is also included for cases where direct client-side fetching is blocked by CORS. This removes the `selenium` dependency and improves reliability.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-12f11941-9c42-4699-998a-da637b32d362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-12f11941-9c42-4699-998a-da637b32d362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

