### PR TITLE
fix(bot): sync DB calls via sync_to_async, GlitchTip env in containers

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,6 +29,9 @@ services:
       STATIC_ROOT: /app/staticfiles
       TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN}
       TELEGRAM_BOT_USERNAME: ${TELEGRAM_BOT_USERNAME}
+      GLITCHTIP_DSN: ${GLITCHTIP_DSN:-}
+      GLITCHTIP_ENVIRONMENT: ${GLITCHTIP_ENVIRONMENT:-}
+      GLITCHTIP_RELEASE: ${GLITCHTIP_RELEASE:-}
     volumes:
       - static_volume:/app/staticfiles
     depends_on:
@@ -49,6 +52,9 @@ services:
       ALLOWED_HOSTS: ${ALLOWED_HOSTS:-localhost,127.0.0.1}
       TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN}
       TELEGRAM_BOT_USERNAME: ${TELEGRAM_BOT_USERNAME}
+      GLITCHTIP_DSN: ${GLITCHTIP_DSN:-}
+      GLITCHTIP_ENVIRONMENT: ${GLITCHTIP_ENVIRONMENT:-}
+      GLITCHTIP_RELEASE: ${GLITCHTIP_RELEASE:-}
     depends_on:
       db:
         condition: service_healthy

--- a/src/planner/bot.py
+++ b/src/planner/bot.py
@@ -11,6 +11,7 @@ import django
 django.setup()
 
 import sentry_sdk  # noqa: E402
+from asgiref.sync import sync_to_async  # noqa: E402
 from django.conf import settings  # noqa: E402
 from telegram import Chat, Update  # noqa: E402
 from telegram.ext import (  # noqa: E402
@@ -46,16 +47,16 @@ async def start_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
 
 async def _link_account(chat: Chat, token_str: str) -> None:
     """Validate token and link Telegram account to a user."""
-    if _is_chat_already_linked(chat.id):
+    if await sync_to_async(_is_chat_already_linked)(chat.id):
         await chat.send_message("This Telegram account is already linked.")
         return
 
-    link_token = _find_valid_token(token_str)
+    link_token = await sync_to_async(_find_valid_token)(token_str)
     if link_token is None:
         await chat.send_message("Invalid or expired token. Please generate a new link.")
         return
 
-    _consume_token_and_save_profile(link_token, chat_id=chat.id)
+    await sync_to_async(_consume_token_and_save_profile)(link_token, chat_id=chat.id)
     await chat.send_message("Your Telegram account has been successfully linked!")
 
 


### PR DESCRIPTION
## Summary

- **SynchronousOnlyOperation crash**: функции `_is_chat_already_linked`, `_find_valid_token`, `_consume_token_and_save_profile` вызывались напрямую из async-контекста PTB. Обёрнуты в `sync_to_async` — Django ORM теперь выполняется в thread pool.
- **GlitchTip DSN не попадал в контейнеры**: переменные `GLITCHTIP_DSN/ENVIRONMENT/RELEASE` записывались деплой-скриптом в `.env`, но не были объявлены в секции `environment` сервисов `web` и `bot` в `docker-compose.prod.yml`, поэтому Docker их не инжектил.

## Test plan

- [ ] Отправить боту `/start <token>` — аккаунт успешно привязывается, ошибки `SynchronousOnlyOperation` нет
- [ ] После деплоя `docker inspect food-purchase-planner-bot-1 | grep GLITCHTIP_DSN` возвращает значение
- [ ] Ошибки в боте появляются в GlitchTip

🤖 Generated with [Claude Code](https://claude.com/claude-code)