### PR TITLE
fix(auth): tolerate clock skew in Telegram auth_date validation

### DIFF
--- a/src/planner/tests/test_config.py
+++ b/src/planner/tests/test_config.py
@@ -13,6 +13,7 @@ from config.exceptions import _flatten_detail
 from planner.models import UserTelegramProfile
 from planner.views_telegram import (
     MAX_AUTH_AGE_SECONDS,
+    MAX_CLOCK_SKEW_SECONDS,
     _build_username,
     _is_auth_date_fresh,
     _verify_telegram_auth,
@@ -181,6 +182,9 @@ class IsAuthDateFreshTests(TestCase):
 
     def test_timestamp_10_minutes_ago_rejected(self):
         self.assertFalse(_is_auth_date_fresh(int(time.time()) - 10 * 60))
+
+    def test_slight_clock_skew_accepted(self):
+        self.assertTrue(_is_auth_date_fresh(int(time.time()) + MAX_CLOCK_SKEW_SECONDS - 1))
 
     def test_future_timestamp_rejected(self):
         self.assertFalse(_is_auth_date_fresh(int(time.time()) + 60))

--- a/src/planner/views_telegram.py
+++ b/src/planner/views_telegram.py
@@ -27,6 +27,7 @@ User = get_user_model()
 
 LINK_TOKEN_EXPIRY_MINUTES = 15
 MAX_AUTH_AGE_SECONDS = 300  # 5 minutes — limits replay window
+MAX_CLOCK_SKEW_SECONDS = 10  # tolerance for clock differences between servers
 
 
 class TelegramLoginCallbackView(View):
@@ -146,9 +147,13 @@ def _verify_telegram_auth(data: dict, bot_token: str) -> bool:
 
 
 def _is_auth_date_fresh(auth_date: int) -> bool:
-    """Return True if the auth_date timestamp is recent and not in the future."""
+    """Return True if the auth_date timestamp is recent enough.
+
+    Allows a small clock-skew tolerance because auth_date comes from
+    Telegram's servers whose clock may be slightly ahead of ours.
+    """
     age_seconds = timezone.now().timestamp() - auth_date
-    return 0 <= age_seconds <= MAX_AUTH_AGE_SECONDS
+    return -MAX_CLOCK_SKEW_SECONDS <= age_seconds <= MAX_AUTH_AGE_SECONDS
 
 
 def _get_or_create_user(telegram_id: int, data: dict):


### PR DESCRIPTION
The strict `0 <= age_seconds` check in `_is_auth_date_fresh` rejected
valid Telegram Login Widget auth when the server clock was even slightly
behind Telegram's servers. Add a 10-second clock-skew tolerance so that
minor time differences no longer cause false "Auth data expired" errors.

https://claude.ai/code/session_01U5DfFNHNTXyVN3WPrhEdJL