### PR TITLE
fix(auth): increase Telegram auth_date TTL to 1 day (86400s)

### DIFF
--- a/src/planner/tests/test_config.py
+++ b/src/planner/tests/test_config.py
@@ -180,8 +180,11 @@ class IsAuthDateFreshTests(TestCase):
     def test_timestamp_4_minutes_ago_accepted(self):
         self.assertTrue(_is_auth_date_fresh(int(time.time()) - 4 * 60))
 
-    def test_timestamp_10_minutes_ago_rejected(self):
-        self.assertFalse(_is_auth_date_fresh(int(time.time()) - 10 * 60))
+    def test_timestamp_10_minutes_ago_accepted(self):
+        self.assertTrue(_is_auth_date_fresh(int(time.time()) - 10 * 60))
+
+    def test_timestamp_2_days_ago_rejected(self):
+        self.assertFalse(_is_auth_date_fresh(int(time.time()) - 2 * 86400))
 
     def test_slight_clock_skew_accepted(self):
         self.assertTrue(_is_auth_date_fresh(int(time.time()) + MAX_CLOCK_SKEW_SECONDS - 1))
@@ -229,7 +232,7 @@ class TelegramLoginCallbackTests(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_expired_auth_date_returns_400(self):
-        data = _make_auth_data(age_seconds=600)  # 10 min > 5 min TTL
+        data = _make_auth_data(age_seconds=90000)  # 25 hours > 1 day TTL
         with self.settings(TELEGRAM_BOT_TOKEN=BOT_TOKEN):
             response = self._get_callback(data)
         self.assertEqual(response.status_code, 400)

--- a/src/planner/views_telegram.py
+++ b/src/planner/views_telegram.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 LINK_TOKEN_EXPIRY_MINUTES = 15
-MAX_AUTH_AGE_SECONDS = 300  # 5 minutes — limits replay window
+MAX_AUTH_AGE_SECONDS = 86400  # 1 day — Telegram Login Widget caches auth sessions
 MAX_CLOCK_SKEW_SECONDS = 10  # tolerance for clock differences between servers
 
 


### PR DESCRIPTION
Telegram Login Widget caches authorization sessions on the client side
(via oauth.telegram.org cookies). On subsequent logins, the widget
silently returns the original auth_date without re-authenticating,
causing valid logins to be rejected with "Auth data expired".

Increase MAX_AUTH_AGE_SECONDS from 300s to 86400s (1 day) to match
django-telegram-login and other widely-used libraries. HMAC signature
verification remains the primary authenticity guarantee.

https://claude.ai/code/session_01DvXMdjFkyM725yUvsdxeBq