### PR TITLE
Remove auth_date freshness validation from Telegram login

### DIFF
--- a/src/planner/tests/test_config.py
+++ b/src/planner/tests/test_config.py
@@ -12,10 +12,7 @@ from django.test import Client, TestCase
 from config.exceptions import _flatten_detail
 from planner.models import UserTelegramProfile
 from planner.views_telegram import (
-    MAX_AUTH_AGE_SECONDS,
-    MAX_CLOCK_SKEW_SECONDS,
     _build_username,
-    _is_auth_date_fresh,
     _verify_telegram_auth,
 )
 
@@ -171,28 +168,6 @@ class VerifyTelegramAuthTests(TestCase):
         self.assertEqual(set(data.keys()), original_keys)
 
 
-class IsAuthDateFreshTests(TestCase):
-    """Unit tests for _is_auth_date_fresh."""
-
-    def test_fresh_timestamp_accepted(self):
-        self.assertTrue(_is_auth_date_fresh(int(time.time())))
-
-    def test_timestamp_4_minutes_ago_accepted(self):
-        self.assertTrue(_is_auth_date_fresh(int(time.time()) - 4 * 60))
-
-    def test_timestamp_10_minutes_ago_accepted(self):
-        self.assertTrue(_is_auth_date_fresh(int(time.time()) - 10 * 60))
-
-    def test_timestamp_2_days_ago_rejected(self):
-        self.assertFalse(_is_auth_date_fresh(int(time.time()) - 2 * 86400))
-
-    def test_slight_clock_skew_accepted(self):
-        self.assertTrue(_is_auth_date_fresh(int(time.time()) + MAX_CLOCK_SKEW_SECONDS - 1))
-
-    def test_future_timestamp_rejected(self):
-        self.assertFalse(_is_auth_date_fresh(int(time.time()) + 60))
-
-
 class BuildUsernameTests(TestCase):
     """Unit tests for _build_username."""
 
@@ -230,12 +205,6 @@ class TelegramLoginCallbackTests(TestCase):
         with self.settings(TELEGRAM_BOT_TOKEN=BOT_TOKEN):
             response = self._get_callback(data)
         self.assertEqual(response.status_code, 403)
-
-    def test_expired_auth_date_returns_400(self):
-        data = _make_auth_data(age_seconds=90000)  # 25 hours > 1 day TTL
-        with self.settings(TELEGRAM_BOT_TOKEN=BOT_TOKEN):
-            response = self._get_callback(data)
-        self.assertEqual(response.status_code, 400)
 
     def test_existing_user_logs_in_and_redirects(self):
         user = User.objects.create_user(username="tguser")
@@ -364,14 +333,8 @@ class TelegramLoginCallbackEdgeCaseTests(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertTrue(User.objects.filter(username="user_777777").exists())
 
-    def test_auth_date_at_exact_ttl_boundary_rejected(self):
-        data = _make_auth_data(age_seconds=MAX_AUTH_AGE_SECONDS + 1)
-        with self.settings(TELEGRAM_BOT_TOKEN=BOT_TOKEN):
-            response = self.client.get("/telegram/callback/", data)
-        self.assertEqual(response.status_code, 400)
-
-    def test_auth_date_just_within_ttl_accepted(self):
-        data = _make_auth_data(telegram_id=888888, age_seconds=MAX_AUTH_AGE_SECONDS - 1)
+    def test_old_auth_date_still_accepted(self):
+        data = _make_auth_data(telegram_id=888888, age_seconds=90000)  # 25 hours
         with self.settings(TELEGRAM_BOT_TOKEN=BOT_TOKEN):
             response = self.client.get("/telegram/callback/", data)
         self.assertEqual(response.status_code, 302)

--- a/src/planner/views_telegram.py
+++ b/src/planner/views_telegram.py
@@ -26,8 +26,6 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 LINK_TOKEN_EXPIRY_MINUTES = 15
-MAX_AUTH_AGE_SECONDS = 86400  # 1 day — Telegram Login Widget caches auth sessions
-MAX_CLOCK_SKEW_SECONDS = 10  # tolerance for clock differences between servers
 
 
 class TelegramLoginCallbackView(View):
@@ -57,13 +55,9 @@ class TelegramLoginCallbackView(View):
             return HttpResponseForbidden("Invalid signature")
 
         try:
-            auth_date = int(data["auth_date"])
             telegram_id = int(data["id"])
         except (KeyError, ValueError):
             return HttpResponseBadRequest("Invalid auth data fields")
-
-        if not _is_auth_date_fresh(auth_date):
-            return HttpResponseBadRequest("Auth data expired, please try again")
 
         user = _get_or_create_user(telegram_id, data)
 
@@ -144,16 +138,6 @@ def _verify_telegram_auth(data: dict, bot_token: str) -> bool:
         secret_key, data_check_string.encode(), hashlib.sha256
     ).hexdigest()
     return hmac.compare_digest(expected_hash, received_hash)
-
-
-def _is_auth_date_fresh(auth_date: int) -> bool:
-    """Return True if the auth_date timestamp is recent enough.
-
-    Allows a small clock-skew tolerance because auth_date comes from
-    Telegram's servers whose clock may be slightly ahead of ours.
-    """
-    age_seconds = timezone.now().timestamp() - auth_date
-    return -MAX_CLOCK_SKEW_SECONDS <= age_seconds <= MAX_AUTH_AGE_SECONDS
 
 
 def _get_or_create_user(telegram_id: int, data: dict):


### PR DESCRIPTION
## Summary
This PR removes the authentication date freshness validation from the Telegram login callback flow. The `_is_auth_date_fresh()` function and related constants have been removed, allowing login requests with any auth_date timestamp to be accepted.

## Key Changes
- Removed `MAX_AUTH_AGE_SECONDS` and `MAX_CLOCK_SKEW_SECONDS` constants from `views_telegram.py`
- Deleted the `_is_auth_date_fresh()` function that validated auth_date timestamps
- Removed the auth_date freshness check from `TelegramLoginCallbackView.get()` that previously returned 400 for expired auth data
- Removed all related unit tests from `test_config.py`:
  - `IsAuthDateFreshTests` test class (6 test methods)
  - `test_expired_auth_date_returns_400` 
  - `test_auth_date_at_exact_ttl_boundary_rejected`
  - `test_auth_date_just_within_ttl_accepted` (replaced with `test_old_auth_date_still_accepted`)

## Implementation Details
The auth_date field is still extracted from the request data but is no longer validated for freshness. The signature verification via `_verify_telegram_auth()` remains in place as the primary security mechanism. This change simplifies the authentication flow by removing the 1-day TTL restriction that was previously enforced.

https://claude.ai/code/session_012AqpT1qvJ5Qq8Ne39YetEG