### PR TITLE
feat(telegram): add SOCKS5 proxy support for Telegram API requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,6 @@ POSTGRES_DB=planner
 # Telegram bot
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_BOT_USERNAME=
+
+# SOCKS5 proxy for Telegram API (required — bot fails to start without it)
+SOCKS5_PROXY_URL=socks5://user:pass@host:port

--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -53,6 +53,7 @@ jobs:
           [ -z "$POSTGRES_PASSWORD" ] && MISSING="$MISSING POSTGRES_PASSWORD"
           [ -z "$SECRET_KEY" ] && MISSING="$MISSING SECRET_KEY"
           [ -z "$ALLOWED_HOSTS" ] && MISSING="$MISSING ALLOWED_HOSTS"
+          [ -z "$SOCKS5_PROXY_URL" ] && MISSING="$MISSING SOCKS5_PROXY_URL"
           if [ -n "$MISSING" ]; then
             echo "::error::Required secrets are not set:$MISSING Add them in Settings → Secrets and variables → Actions."
             exit 1
@@ -65,6 +66,7 @@ jobs:
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
           ALLOWED_HOSTS: ${{ secrets.ALLOWED_HOSTS }}
+          SOCKS5_PROXY_URL: ${{ secrets.SOCKS5_PROXY_URL }}
 
       - name: Check deploy files exist
         run: |
@@ -102,12 +104,13 @@ jobs:
           TELEGRAM_BOT_USERNAME: ${{ secrets.TELEGRAM_BOT_USERNAME }}
           LOGTIDE_API_URL: ${{ secrets.LOGTIDE_API_URL }}
           LOGTIDE_API_KEY: ${{ secrets.LOGTIDE_API_KEY }}
+          SOCKS5_PROXY_URL: ${{ secrets.SOCKS5_PROXY_URL }}
         with:
           host: ${{ secrets.VDS_SSH_HOST }}
           username: ${{ secrets.VDS_SSH_USER }}
           key: ${{ secrets.VDS_SSH_KEY }}
           port: ${{ secrets.VDS_SSH_PORT }}
-          envs: IMAGE_TAG,DEPLOY_WORKDIR,GITHUB_REPOSITORY,GHCR_USER,GHCR_TOKEN,POSTGRES_PASSWORD,SECRET_KEY,POSTGRES_USER,POSTGRES_DB,ALLOWED_HOSTS,CSRF_TRUSTED_ORIGINS,GLITCHTIP_DSN,GLITCHTIP_ENVIRONMENT,GLITCHTIP_RELEASE,TELEGRAM_BOT_TOKEN,TELEGRAM_BOT_USERNAME,LOGTIDE_API_URL,LOGTIDE_API_KEY
+          envs: IMAGE_TAG,DEPLOY_WORKDIR,GITHUB_REPOSITORY,GHCR_USER,GHCR_TOKEN,POSTGRES_PASSWORD,SECRET_KEY,POSTGRES_USER,POSTGRES_DB,ALLOWED_HOSTS,CSRF_TRUSTED_ORIGINS,GLITCHTIP_DSN,GLITCHTIP_ENVIRONMENT,GLITCHTIP_RELEASE,TELEGRAM_BOT_TOKEN,TELEGRAM_BOT_USERNAME,LOGTIDE_API_URL,LOGTIDE_API_KEY,SOCKS5_PROXY_URL
           script: |
             set -e
             WORKDIR="${DEPLOY_WORKDIR:-.}"
@@ -133,6 +136,7 @@ jobs:
               [ -n "$TELEGRAM_BOT_USERNAME" ] && printf 'TELEGRAM_BOT_USERNAME="%s"\n' "${TELEGRAM_BOT_USERNAME//\"/\\\"}"
               [ -n "$LOGTIDE_API_URL" ] && printf 'LOGTIDE_API_URL="%s"\n' "${LOGTIDE_API_URL//\"/\\\"}"
               [ -n "$LOGTIDE_API_KEY" ] && printf 'LOGTIDE_API_KEY="%s"\n' "${LOGTIDE_API_KEY//\"/\\\"}"
+              printf 'SOCKS5_PROXY_URL="%s"\n' "${SOCKS5_PROXY_URL//\"/\\\"}"
             } > .env
             chmod 600 .env
             bash deploy.sh "${IMAGE_TAG}"

--- a/.github/workflows/ci-lint-test.yml
+++ b/.github/workflows/ci-lint-test.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: mypy
         run: uv run mypy src
+        env:
+          SOCKS5_PROXY_URL: socks5://localhost:1080
 
   test:
     runs-on: ubuntu-latest
@@ -47,3 +49,5 @@ jobs:
 
       - name: Run Django tests
         run: uv run python src/manage.py test
+        env:
+          SOCKS5_PROXY_URL: socks5://localhost:1080

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,3 +82,5 @@ pytest + pytest-django. Config in `pyproject.toml` sets `DJANGO_SETTINGS_MODULE 
 ## CI/CD
 
 GitHub Actions: lint+test on push/PR to master → build Docker image to ghcr.io → deploy to VDS via SSH + docker-compose.
+
+When adding, removing, or renaming environment variables, update the deploy workflow (`.github/workflows/`) — env vars are passed explicitly to containers in the deploy step.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "gunicorn>=25.0.1",
     "psycopg[binary]>=3.3.2",
     "python-dotenv>=1.2.1",
-    "python-telegram-bot[rate-limiter]>=21.0",
+    "python-telegram-bot[rate-limiter,socks]>=21.0",
     "sentry-sdk>=2.55.0",
     "logtide-sdk[django]>=0.8.5",
 ]

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -164,6 +164,7 @@ LOGOUT_REDIRECT_URL = "/login/"
 # Telegram bot settings
 TELEGRAM_BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN", "")
 TELEGRAM_BOT_USERNAME = os.environ.get("TELEGRAM_BOT_USERNAME", "")
+SOCKS5_PROXY_URL = os.environ["SOCKS5_PROXY_URL"]
 
 # LogTide structured logging
 _logtide_api_url = os.environ.get("LOGTIDE_API_URL", "")

--- a/src/planner/bot.py
+++ b/src/planner/bot.py
@@ -98,6 +98,8 @@ def run_bot() -> None:
     application = (
         ApplicationBuilder()
         .token(settings.TELEGRAM_BOT_TOKEN)
+        .proxy(settings.SOCKS5_PROXY_URL)
+        .get_updates_proxy(settings.SOCKS5_PROXY_URL)
         .rate_limiter(AIORateLimiter())
         .build()
     )

--- a/src/planner/management/commands/send_telegram_broadcast.py
+++ b/src/planner/management/commands/send_telegram_broadcast.py
@@ -108,6 +108,8 @@ class Command(BaseCommand):
         application = (
             ApplicationBuilder()
             .token(settings.TELEGRAM_BOT_TOKEN)
+            .proxy(settings.SOCKS5_PROXY_URL)
+            .get_updates_proxy(settings.SOCKS5_PROXY_URL)
             .rate_limiter(AIORateLimiter())
             .build()
         )

--- a/src/planner/tests/test_config.py
+++ b/src/planner/tests/test_config.py
@@ -418,3 +418,13 @@ class TelegramLoginCallbackEdgeCaseTests(TestCase):
         with self.settings(TELEGRAM_BOT_TOKEN=BOT_TOKEN):
             response = self.client.get("/telegram/callback/", data)
         self.assertIn(response.status_code, [400, 403])
+
+
+class Socks5ProxySettingTests(TestCase):
+    """Tests for SOCKS5_PROXY_URL setting."""
+
+    def test_socks5_proxy_url_from_env(self):
+        from django.conf import settings
+
+        self.assertTrue(hasattr(settings, "SOCKS5_PROXY_URL"))
+        self.assertTrue(len(settings.SOCKS5_PROXY_URL) > 0)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -217,7 +217,7 @@ dependencies = [
     { name = "logtide-sdk", extra = ["django"] },
     { name = "psycopg", extra = ["binary"] },
     { name = "python-dotenv" },
-    { name = "python-telegram-bot", extra = ["rate-limiter"] },
+    { name = "python-telegram-bot", extra = ["rate-limiter", "socks"] },
     { name = "sentry-sdk" },
 ]
 
@@ -240,7 +240,7 @@ requires-dist = [
     { name = "logtide-sdk", extras = ["django"], specifier = ">=0.8.5" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.2" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
-    { name = "python-telegram-bot", extras = ["rate-limiter"], specifier = ">=21.0" },
+    { name = "python-telegram-bot", extras = ["rate-limiter", "socks"], specifier = ">=21.0" },
     { name = "sentry-sdk", specifier = ">=2.55.0" },
 ]
 
@@ -302,6 +302,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
 ]
 
 [[package]]
@@ -595,6 +600,9 @@ wheels = [
 rate-limiter = [
     { name = "aiolimiter" },
 ]
+socks = [
+    { name = "httpx", extra = ["socks"] },
+]
 
 [[package]]
 name = "pyyaml"
@@ -683,6 +691,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/b8/285293dc60fc198fffc3fcdbc7c6d4e646e0f74e61461c355d40faa64ceb/sentry_sdk-2.55.0.tar.gz", hash = "sha256:3774c4d8820720ca4101548131b9c162f4c9426eb7f4d24aca453012a7470f69", size = 424505, upload-time = "2026-03-17T14:15:51.707Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/66/20465097782d7e1e742d846407ea7262d338c6e876ddddad38ca8907b38f/sentry_sdk-2.55.0-py2.py3-none-any.whl", hash = "sha256:97026981cb15699394474a196b88503a393cbc58d182ece0d3abe12b9bd978d4", size = 449284, upload-time = "2026-03-17T14:15:49.604Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Все исходящие запросы к Telegram API (sendMessage, getUpdates, polling) маршрутизируются через SOCKS5-прокси
- Добавлен обязательный `SOCKS5_PROXY_URL` — приложение падает при старте без него
- Добавлена зависимость `socksio` через extra `python-telegram-bot[socks]`

## Изменения
- **pyproject.toml** — добавлен extra `socks` к `python-telegram-bot`
- **settings.py** — обязательная переменная `SOCKS5_PROXY_URL`
- **bot.py** — `.proxy()` и `.get_updates_proxy()` в ApplicationBuilder
- **send_telegram_broadcast.py** — аналогичная настройка прокси
- **.env.example** — пример переменной
- **test_config.py** — тест чтения `SOCKS5_PROXY_URL` из env

## Test plan
- [x] `uv sync` — `socksio` установлен
- [x] `uv run ruff check src` — без ошибок
- [x] `uv run mypy src` — без ошибок
- [x] `uv run pytest -v` — 365 тестов пройдено