### PR TITLE
Remove unnecessary password hashing from tests (158s → 3s)

### DIFF
--- a/src/planner/tests/test_api_contract.py
+++ b/src/planner/tests/test_api_contract.py
@@ -23,7 +23,7 @@ class ApiTestBase(TestCase):
     def setUp(self):
         self.client = Client()
         self.user = User.objects.create_user(
-            username="testuser", password="testpass123", email="test@example.com"
+            username="testuser", email="test@example.com"
         )
         self.client.force_login(self.user)
 
@@ -100,7 +100,7 @@ class IngredientApiTests(ApiTestBase):
 
     def test_ingredient_delete_system_ingredient_400(self):
         system_user = User.objects.create_user(
-            username="system", password="x", email="system@local"
+            username="system", email="system@local"
         )
         ing = Ingredient.objects.create(user=system_user, name="SystemIng", calories=0)
         self.client.force_login(system_user)
@@ -110,7 +110,7 @@ class IngredientApiTests(ApiTestBase):
 
     def test_ingredient_update_system_ingredient_400(self):
         system_user = User.objects.create_user(
-            username="system", password="x", email="system@local"
+            username="system", email="system@local"
         )
         ing = Ingredient.objects.create(user=system_user, name="SystemIng", calories=0)
         self.client.force_login(system_user)
@@ -257,7 +257,7 @@ class RecipeFriendEditorTests(ApiTestBase):
     def setUp(self):
         super().setUp()
         self.owner = User.objects.create_user(
-            username="owner", password="pass", email="owner@example.com"
+            username="owner", email="owner@example.com"
         )
         self.ing = Ingredient.objects.create(
             user=self.owner, name="Tomato", calories=18, protein=1, fat=0, carbs=4
@@ -395,7 +395,7 @@ class RecipeListQueryCountTests(TestCase):
 
     def setUp(self):
         self.viewer = User.objects.create_user(
-            username="viewer", password="pass", email="viewer@test.com"
+            username="viewer", email="viewer@test.com"
         )
         self.client = Client()
         self.client.force_login(self.viewer)
@@ -406,7 +406,7 @@ class RecipeListQueryCountTests(TestCase):
             RecipeListQueryCountTests._user_seq += 1
             seq = RecipeListQueryCountTests._user_seq
             other = User.objects.create_user(
-                username=f"other_{seq}", password="pass", email=f"o{seq}@test.com"
+                username=f"other_{seq}", email=f"o{seq}@test.com"
             )
             ing = Ingredient.objects.create(
                 user=other,
@@ -607,7 +607,7 @@ class MultiMenuApiTests(ApiTestBase):
 
     def test_menu_detail_404_for_other_user(self):
         other = User.objects.create_user(
-            username="other", password="pass", email="other@example.com"
+            username="other", email="other@example.com"
         )
         menu = Menu.objects.create(user=other, name="Private")
         response = self.client.get(f"/api/menus/{menu.id}/")
@@ -693,7 +693,7 @@ class FriendsApiTests(ApiTestBase):
 
     def test_send_request_creates_pending_request_by_code(self):
         other = User.objects.create_user(
-            username="friend", password="pass", email="friend@example.com"
+            username="friend", email="friend@example.com"
         )
         code_obj = UserFriendCode.objects.create(user=other)
 
@@ -729,7 +729,7 @@ class FriendsApiTests(ApiTestBase):
 
     def test_send_request_already_friends_400(self):
         other = User.objects.create_user(
-            username="friend", password="pass", email="friend@example.com"
+            username="friend", email="friend@example.com"
         )
         code_obj = UserFriendCode.objects.create(user=other)
         FriendRequest.objects.create(
@@ -748,7 +748,7 @@ class FriendsApiTests(ApiTestBase):
 
     def test_friend_requests_list_shows_incoming_pending_only(self):
         other = User.objects.create_user(
-            username="friend", password="pass", email="friend@example.com"
+            username="friend", email="friend@example.com"
         )
         FriendRequest.objects.create(
             from_user=other,
@@ -775,7 +775,7 @@ class FriendsApiTests(ApiTestBase):
 
     def test_accept_request_marks_accepted_and_cancels_reverse_pending(self):
         other = User.objects.create_user(
-            username="friend", password="pass", email="friend@example.com"
+            username="friend", email="friend@example.com"
         )
         incoming = FriendRequest.objects.create(
             from_user=other,
@@ -800,7 +800,7 @@ class FriendsApiTests(ApiTestBase):
 
     def test_decline_request_marks_declined(self):
         other = User.objects.create_user(
-            username="friend", password="pass", email="friend@example.com"
+            username="friend", email="friend@example.com"
         )
         incoming = FriendRequest.objects.create(
             from_user=other,
@@ -818,7 +818,7 @@ class FriendsApiTests(ApiTestBase):
 
     def test_friends_list_returns_accepted_friends(self):
         other = User.objects.create_user(
-            username="friend", password="pass", email="friend@example.com"
+            username="friend", email="friend@example.com"
         )
         accepted = FriendRequest.objects.create(
             from_user=self.user,
@@ -842,7 +842,7 @@ class FriendsApiTests(ApiTestBase):
 
     def test_remove_friend_changes_status_to_removed_and_errors_if_not_friend(self):
         other = User.objects.create_user(
-            username="friend", password="pass", email="friend@example.com"
+            username="friend", email="friend@example.com"
         )
         accepted = FriendRequest.objects.create(
             from_user=self.user,
@@ -867,7 +867,7 @@ class EditRecipesRequestFlowTests(ApiTestBase):
     def setUp(self):
         super().setUp()
         self.other = User.objects.create_user(
-            username="friend", password="pass", email="friend@example.com"
+            username="friend", email="friend@example.com"
         )
         self.fr = FriendRequest.objects.create(
             from_user=self.user,
@@ -1048,7 +1048,7 @@ class RecipeCategoryApiTests(ApiTestBase):
 
     def test_category_list_includes_system_categories(self):
         system_user = User.objects.create_user(
-            username="system", password="x", is_active=False
+            username="system", is_active=False
         )
         RecipeCategory.objects.create(user=system_user, name="Завтрак")
         RecipeCategory.objects.create(user=self.user, name="Мои блюда")

--- a/src/planner/tests/test_api_edge_cases.py
+++ b/src/planner/tests/test_api_edge_cases.py
@@ -83,7 +83,7 @@ class IngredientApiEdgeCaseTests(TestCase):
     def setUp(self):
         self.client = Client()
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.client.force_login(self.user)
 
@@ -106,7 +106,7 @@ class IngredientApiEdgeCaseTests(TestCase):
 
     def test_delete_other_users_ingredient_forbidden(self):
         other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         ing = Ingredient.objects.create(user=other, name="Secret", calories=0)
         response = self.client.delete(f"/api/ingredients/{ing.id}/")
@@ -115,7 +115,7 @@ class IngredientApiEdgeCaseTests(TestCase):
     def test_list_ingredients_returns_all_users(self):
         """Ingredients from all users should be visible in the list."""
         other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         Ingredient.objects.create(user=self.user, name="Mine")
         Ingredient.objects.create(user=other, name="Other")
@@ -162,7 +162,7 @@ class IngredientApiEdgeCaseTests(TestCase):
 
     def test_update_other_users_ingredient_forbidden(self):
         other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         ing = Ingredient.objects.create(user=other, name="Secret", calories=0)
         response = self.client.patch(
@@ -179,14 +179,14 @@ class RecipeApiEdgeCaseTests(TestCase):
     def setUp(self):
         self.client = Client()
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.client.force_login(self.user)
         self.ing = Ingredient.objects.create(user=self.user, name="Tomato", calories=18)
 
     def test_recipe_list_includes_other_users_recipes(self):
         other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         Recipe.objects.create(
             user=self.user, name="My Recipe", description="", instructions=""
@@ -201,7 +201,7 @@ class RecipeApiEdgeCaseTests(TestCase):
 
     def test_recipe_delete_other_users_recipe_forbidden(self):
         other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         recipe = Recipe.objects.create(
             user=other, name="Private", description="", instructions=""
@@ -211,7 +211,7 @@ class RecipeApiEdgeCaseTests(TestCase):
 
     def test_recipe_update_other_users_recipe_forbidden(self):
         other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         recipe = Recipe.objects.create(
             user=other, name="Private", description="", instructions=""
@@ -273,7 +273,7 @@ class MenuApiEdgeCaseTests(TestCase):
     def setUp(self):
         self.client = Client()
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.client.force_login(self.user)
 
@@ -364,7 +364,7 @@ class MenuSetActiveTests(TestCase):
     def setUp(self):
         self.client = Client()
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.client.force_login(self.user)
 
@@ -378,7 +378,7 @@ class MenuSetActiveTests(TestCase):
 
     def test_set_active_other_users_menu_404(self):
         other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         menu = Menu.objects.create(user=other, name="Other")
         response = self.client.post(f"/api/menus/{menu.id}/set-active/")
@@ -391,7 +391,7 @@ class ShoppingListEdgeCaseTests(TestCase):
     def setUp(self):
         self.client = Client()
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.client.force_login(self.user)
 
@@ -439,7 +439,7 @@ class ShoppingListEdgeCaseTests(TestCase):
 
     def test_shopping_list_other_users_menu_id_404(self):
         other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         menu = Menu.objects.create(user=other, name="Other")
         response = self.client.post(
@@ -462,7 +462,7 @@ class FriendsApiEdgeCaseTests(TestCase):
     def setUp(self):
         self.client = Client()
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.client.force_login(self.user)
 
@@ -477,7 +477,7 @@ class FriendsApiEdgeCaseTests(TestCase):
     def test_send_request_already_pending(self):
         """Sending a second request when a pending one exists should still create."""
         other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         code_obj = UserFriendCode.objects.create(user=other)
         FriendRequest.objects.create(
@@ -495,7 +495,7 @@ class FriendsApiEdgeCaseTests(TestCase):
     def test_accept_request_wrong_user(self):
         """Only to_user can accept a friend request."""
         other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         fr = FriendRequest.objects.create(
             from_user=self.user,
@@ -507,7 +507,7 @@ class FriendsApiEdgeCaseTests(TestCase):
 
     def test_decline_request_wrong_user(self):
         other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         fr = FriendRequest.objects.create(
             from_user=self.user,
@@ -519,7 +519,7 @@ class FriendsApiEdgeCaseTests(TestCase):
 
     def test_accept_already_accepted_request(self):
         other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         fr = FriendRequest.objects.create(
             from_user=other,
@@ -540,11 +540,11 @@ class EditRecipesRequestEdgeCaseTests(TestCase):
     def setUp(self):
         self.client = Client()
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.client.force_login(self.user)
         self.other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
 
     def test_send_edit_request_not_friends_400(self):

--- a/src/planner/tests/test_assignments.py
+++ b/src/planner/tests/test_assignments.py
@@ -19,7 +19,7 @@ User = get_user_model()
 class MenuSlotAssignmentModelTests(TestCase):
     def setUp(self):
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.menu = Menu.objects.create(user=self.user, name="Test")
         self.recipe = Recipe.objects.create(
@@ -46,7 +46,7 @@ class MenuSlotAssignmentModelTests(TestCase):
 
     def test_ordering_by_pk(self):
         bob = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         a1 = MenuSlotAssignment.objects.create(menu_slot=self.slot, user=self.user)
         a2 = MenuSlotAssignment.objects.create(menu_slot=self.slot, user=bob)
@@ -58,13 +58,13 @@ class MenuSlotAssignmentModelTests(TestCase):
 class GetMenuMembersTests(TestCase):
     def setUp(self):
         self.alice = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.bob = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         self.carol = User.objects.create_user(
-            username="carol", password="pass", email="carol@test.com"
+            username="carol", email="carol@test.com"
         )
         self.menu = Menu.objects.create(user=self.alice, name="Test")
 
@@ -105,10 +105,10 @@ class GetMenuMembersTests(TestCase):
 class DuplicateMenuWithAssignmentsTests(TestCase):
     def setUp(self):
         self.alice = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.bob = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         self.menu = Menu.objects.create(user=self.alice, name="Original")
         self.recipe = Recipe.objects.create(
@@ -148,7 +148,7 @@ class ApiTestBase(TestCase):
     def setUp(self):
         self.client = Client()
         self.user = User.objects.create_user(
-            username="testuser", password="testpass123", email="test@example.com"
+            username="testuser", email="test@example.com"
         )
         self.client.force_login(self.user)
 
@@ -165,7 +165,7 @@ class MenuMembersEndpointTests(ApiTestBase):
     def test_returns_owner_and_editors(self):
         menu = Menu.objects.create(user=self.user, name="Test")
         bob = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         FriendRequest.objects.create(
             from_user=self.user,
@@ -179,7 +179,7 @@ class MenuMembersEndpointTests(ApiTestBase):
 
     def test_404_for_non_shared_user(self):
         other = User.objects.create_user(
-            username="other", password="pass", email="other@test.com"
+            username="other", email="other@test.com"
         )
         menu = Menu.objects.create(user=other, name="Private")
         response = self.client.get(f"/api/menus/{menu.id}/members/")
@@ -187,7 +187,7 @@ class MenuMembersEndpointTests(ApiTestBase):
 
     def test_read_only_user_can_access(self):
         owner = User.objects.create_user(
-            username="owner", password="pass", email="owner@test.com"
+            username="owner", email="owner@test.com"
         )
         menu = Menu.objects.create(user=owner, name="Shared")
         FriendRequest.objects.create(
@@ -250,7 +250,7 @@ class MenuAssignmentsApiTests(ApiTestBase):
 
     def test_assignments_capped_at_servings_count(self):
         bob = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         FriendRequest.objects.create(
             from_user=self.user,

--- a/src/planner/tests/test_config.py
+++ b/src/planner/tests/test_config.py
@@ -68,7 +68,7 @@ class ExceptionHandlerIntegrationTests(TestCase):
     def setUp(self):
         self.client = Client()
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.client.force_login(self.user)
 
@@ -109,13 +109,13 @@ class ProtectedPagesTests(TestCase):
         self.assertIn("/login/", response.url)
 
     def test_cook_today_renders_for_authenticated_user(self):
-        user = User.objects.create_user(username="alice", password="pass")
+        user = User.objects.create_user(username="alice")
         self.client.force_login(user)
         response = self.client.get("/cook-today/")
         self.assertEqual(response.status_code, 200)
 
     def test_home_renders_for_authenticated_user(self):
-        user = User.objects.create_user(username="alice", password="pass")
+        user = User.objects.create_user(username="alice")
         self.client.force_login(user)
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
@@ -280,7 +280,7 @@ class DeleteUnlinkedUsersCommandTests(TestCase):
         self.assertTrue(User.objects.filter(username="linked").exists())
 
     def test_does_not_delete_superusers(self):
-        User.objects.create_superuser(username="admin", password="pass")
+        User.objects.create_superuser(username="admin")
         self._run_command()
         self.assertTrue(User.objects.filter(username="admin").exists())
 

--- a/src/planner/tests/test_import.py
+++ b/src/planner/tests/test_import.py
@@ -169,7 +169,7 @@ class IngredientImportPageContentApiTests(TestCase):
     def setUp(self):
         self.client = Client()
         self.user = User.objects.create_user(
-            username="testuser", password="testpass123", email="test@example.com"
+            username="testuser", email="test@example.com"
         )
         self.client.force_login(self.user)
 

--- a/src/planner/tests/test_menu_sharing.py
+++ b/src/planner/tests/test_menu_sharing.py
@@ -33,10 +33,10 @@ class MenuShareModelTests(TestCase):
 
     def setUp(self):
         self.alice = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.bob = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         self.menu = Menu.objects.create(user=self.alice, name="Alice Menu")
         FriendRequest.objects.create(
@@ -59,7 +59,7 @@ class MenuShareModelTests(TestCase):
 
     def test_share_menu_not_friend_raises(self):
         stranger = User.objects.create_user(
-            username="stranger", password="pass", email="stranger@test.com"
+            username="stranger", email="stranger@test.com"
         )
         with self.assertRaises(ValidationError):
             share_menu(self.menu, stranger, "read")
@@ -74,10 +74,10 @@ class UserActiveMenuTests(TestCase):
 
     def setUp(self):
         self.alice = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.bob = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         self.menu_a = Menu.objects.create(user=self.alice, name="Menu A")
         self.menu_b = Menu.objects.create(user=self.alice, name="Menu B")
@@ -126,7 +126,7 @@ class ShoppingListServingsTests(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.menu = Menu.objects.create(user=self.user, name="Test")
         self.ing = Ingredient.objects.create(user=self.user, name="Tomato", calories=18)
@@ -169,10 +169,10 @@ class MenuShareAPITests(TestCase):
 
     def setUp(self):
         self.alice = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.bob = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         FriendRequest.objects.create(
             from_user=self.alice,
@@ -210,7 +210,7 @@ class MenuShareAPITests(TestCase):
 
     def test_non_friend_share_rejected(self):
         stranger = User.objects.create_user(
-            username="stranger", password="pass", email="stranger@test.com"
+            username="stranger", email="stranger@test.com"
         )
         resp = self.client_alice.post(
             f"/api/menus/{self.menu.id}/shares/",
@@ -236,10 +236,10 @@ class MenuDetailAccessTests(TestCase):
 
     def setUp(self):
         self.alice = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.bob = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         FriendRequest.objects.create(
             from_user=self.alice,
@@ -290,10 +290,10 @@ class RevokeAllSharesBetweenTests(TestCase):
 
     def setUp(self):
         self.alice = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.bob = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         FriendRequest.objects.create(
             from_user=self.alice,

--- a/src/planner/tests/test_models.py
+++ b/src/planner/tests/test_models.py
@@ -26,7 +26,7 @@ class IngredientModelTests(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
 
     def test_str_returns_name(self):
@@ -53,7 +53,7 @@ class IngredientModelTests(TestCase):
 
     def test_same_name_different_users_allowed(self):
         other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         Ingredient.objects.create(user=self.user, name="Salt")
         ing2 = Ingredient.objects.create(user=other, name="Salt")
@@ -65,7 +65,7 @@ class RecipeCategoryModelTests(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
 
     def test_str_returns_name(self):
@@ -85,7 +85,7 @@ class RecipeCategoryModelTests(TestCase):
 
     def test_same_name_different_users_allowed(self):
         other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         RecipeCategory.objects.create(user=self.user, name="Десерты")
         cat2 = RecipeCategory.objects.create(user=other, name="Десерты")
@@ -111,7 +111,7 @@ class RecipeModelTests(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.ing_a = Ingredient.objects.create(
             user=self.user, name="A", calories=100, protein=10, fat=5, carbs=20
@@ -204,7 +204,7 @@ class RecipeIngredientModelTests(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.ing = Ingredient.objects.create(user=self.user, name="Flour", calories=364)
         self.recipe = Recipe.objects.create(
@@ -249,7 +249,7 @@ class MenuModelTests(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
 
     def test_str_format(self):
@@ -273,7 +273,7 @@ class MenuSlotModelTests(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.menu = Menu.objects.create(user=self.user, name="Test")
         self.recipe = Recipe.objects.create(
@@ -336,7 +336,7 @@ class UserFriendCodeModelTests(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
 
     def test_save_generates_code_when_empty(self):
@@ -367,7 +367,7 @@ class UserFriendCodeModelTests(TestCase):
 
     def test_code_unique(self):
         other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         UserFriendCode.objects.create(user=self.user, code="SAMECODE")
         with self.assertRaises(IntegrityError):
@@ -393,10 +393,10 @@ class FriendRequestModelTests(TestCase):
 
     def setUp(self):
         self.alice = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.bob = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
 
     def test_str_format(self):
@@ -442,7 +442,7 @@ class FriendRequestModelTests(TestCase):
 
     def test_can_edit_recipes_requested_by_set_null_on_delete(self):
         carol = User.objects.create_user(
-            username="carol", password="pass", email="carol@test.com"
+            username="carol", email="carol@test.com"
         )
         fr = FriendRequest.objects.create(
             from_user=self.alice,

--- a/src/planner/tests/test_permissions.py
+++ b/src/planner/tests/test_permissions.py
@@ -20,10 +20,10 @@ class IsOwnerOrReadOnlyTests(TestCase):
         self.factory = RequestFactory()
         self.permission = IsOwnerOrReadOnly()
         self.owner = User.objects.create_user(
-            username="owner", password="pass", email="owner@test.com"
+            username="owner", email="owner@test.com"
         )
         self.other = User.objects.create_user(
-            username="other", password="pass", email="other@test.com"
+            username="other", email="other@test.com"
         )
         self.ingredient = Ingredient.objects.create(
             user=self.owner, name="Salt", calories=0
@@ -67,13 +67,13 @@ class IsOwnerOrFriendEditorOrReadOnlyTests(TestCase):
         self.factory = RequestFactory()
         self.permission = IsOwnerOrFriendEditorOrReadOnly()
         self.owner = User.objects.create_user(
-            username="owner", password="pass", email="owner@test.com"
+            username="owner", email="owner@test.com"
         )
         self.friend = User.objects.create_user(
-            username="friend", password="pass", email="friend@test.com"
+            username="friend", email="friend@test.com"
         )
         self.stranger = User.objects.create_user(
-            username="stranger", password="pass", email="stranger@test.com"
+            username="stranger", email="stranger@test.com"
         )
         self.recipe = Recipe.objects.create(
             user=self.owner, name="Soup", description="", instructions=""
@@ -145,14 +145,14 @@ class IsSystemIngredientTests(TestCase):
 
     def test_system_user_ingredient(self):
         system_user = User.objects.create_user(
-            username="system", password="pass", email="system@test.com"
+            username="system", email="system@test.com"
         )
         ing = Ingredient.objects.create(user=system_user, name="Salt")
         self.assertTrue(is_system_ingredient(ing))
 
     def test_non_system_user_ingredient(self):
         user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         ing = Ingredient.objects.create(user=user, name="Salt")
         self.assertFalse(is_system_ingredient(ing))

--- a/src/planner/tests/test_serializers.py
+++ b/src/planner/tests/test_serializers.py
@@ -33,7 +33,7 @@ class IngredientSerializerTests(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.request = self.factory.get("/")
         self.request.user = self.user
@@ -78,7 +78,7 @@ class IngredientSerializerTests(TestCase):
 
     def test_is_owner_false_for_other_user(self):
         other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         ing = Ingredient.objects.create(user=other, name="Salt")
         serializer = IngredientSerializer(ing, context=self._context())
@@ -112,7 +112,7 @@ class RecipeSerializerTests(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.request = self.factory.get("/")
         self.request.user = self.user
@@ -161,7 +161,7 @@ class RecipeSerializerTests(TestCase):
 
     def test_is_owner_false_for_other(self):
         other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         serializer = RecipeSerializer(self.recipe, context=self._context(user=other))
         self.assertFalse(serializer.data["is_owner"])
@@ -172,7 +172,7 @@ class RecipeSerializerTests(TestCase):
 
     def test_can_edit_true_for_friend_editor_via_context(self):
         other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         ctx = self._context(user=other, editable_owner_ids={self.user.id})
         serializer = RecipeSerializer(self.recipe, context=ctx)
@@ -180,7 +180,7 @@ class RecipeSerializerTests(TestCase):
 
     def test_can_edit_false_for_non_friend(self):
         other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         ctx = self._context(user=other, editable_owner_ids=set())
         serializer = RecipeSerializer(self.recipe, context=ctx)
@@ -189,7 +189,7 @@ class RecipeSerializerTests(TestCase):
     def test_can_edit_fallback_to_db_check_without_context(self):
         """When editable_owner_ids is not in context, falls back to DB check."""
         other = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
         FriendRequest.objects.create(
             from_user=other,
@@ -240,7 +240,7 @@ class RecipeCreateUpdateSerializerTests(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.request = self.factory.post("/")
         self.request.user = self.user
@@ -325,7 +325,7 @@ class MenuItemSerializerTests(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.request = self.factory.get("/")
         self.request.user = self.user
@@ -353,7 +353,7 @@ class MenuSlotsSerializerTests(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.menu = Menu.objects.create(user=self.user, name="Test")
 
@@ -444,7 +444,7 @@ class RecipeCategorySerializerTests(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.request = self.factory.get("/")
         self.request.user = self.user

--- a/src/planner/tests/test_services.py
+++ b/src/planner/tests/test_services.py
@@ -35,7 +35,7 @@ class GetOrCreateFirstMenuTests(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
 
     def test_creates_menu_when_none_exists(self):
@@ -62,7 +62,7 @@ class GetMenuSlotsTests(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.menu = Menu.objects.create(user=self.user, name="Test")
         self.recipe = Recipe.objects.create(
@@ -99,7 +99,7 @@ class GetMenuForUserTests(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
 
     def test_creates_menu_and_returns_slots(self):
@@ -113,7 +113,7 @@ class CalculateShoppingListTests(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.menu = Menu.objects.create(user=self.user, name="Test")
         self.ing_tomato = Ingredient.objects.create(
@@ -229,7 +229,7 @@ class CalculateShoppingListForUserTests(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
 
     def test_creates_menu_and_returns_empty_list(self):
@@ -246,10 +246,10 @@ class GetFriendUserOr404Tests(TestCase):
 
     def setUp(self):
         self.alice = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.bob = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
 
     def test_returns_friend_when_from_user(self):
@@ -293,16 +293,16 @@ class GetEditableOwnerIdsTests(TestCase):
 
     def setUp(self):
         self.editor = User.objects.create_user(
-            username="editor", password="pass", email="editor@test.com"
+            username="editor", email="editor@test.com"
         )
         self.owner_a = User.objects.create_user(
-            username="owner_a", password="pass", email="a@test.com"
+            username="owner_a", email="a@test.com"
         )
         self.owner_b = User.objects.create_user(
-            username="owner_b", password="pass", email="b@test.com"
+            username="owner_b", email="b@test.com"
         )
         self.stranger = User.objects.create_user(
-            username="stranger", password="pass", email="stranger@test.com"
+            username="stranger", email="stranger@test.com"
         )
 
     def test_returns_empty_set_when_no_friends(self):
@@ -361,10 +361,10 @@ class CanFriendEditRecipesTests(TestCase):
 
     def setUp(self):
         self.alice = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.bob = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
 
     def test_true_when_accepted_and_edit_accepted(self):
@@ -421,10 +421,10 @@ class GetFriendRequestBetweenTests(TestCase):
 
     def setUp(self):
         self.alice = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.bob = User.objects.create_user(
-            username="bob", password="pass", email="bob@test.com"
+            username="bob", email="bob@test.com"
         )
 
     def test_returns_accepted_request(self):

--- a/src/planner/tests/test_signals.py
+++ b/src/planner/tests/test_signals.py
@@ -13,7 +13,7 @@ class RecalculateNutritionSignalTests(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(
-            username="alice", password="pass", email="alice@test.com"
+            username="alice", email="alice@test.com"
         )
         self.ing_a = Ingredient.objects.create(
             user=self.user, name="A", calories=100, protein=10, fat=5, carbs=20


### PR DESCRIPTION
## Summary

- Убран параметр `password=` из всех 126 вызовов `create_user` / `create_superuser` в тестах
- Проект использует Telegram-авторизацию, а все тесты работают через `force_login` / `force_authenticate` — пароли нигде не проверяются
- Django хешировал каждый пароль через PBKDF2 с 1.2М итераций (~260мс на вызов), тратя ~130с впустую

**Результат: 158с → 2.9с (ускорение в 54 раза), все 358 тестов проходят.**

## Test plan

- [x] `uv run pytest` — 358 passed in 2.92s
- [x] Проверено отсутствие `client.login()` — нигде не используется, только `force_login`/`force_authenticate`
- [x] Проверено отсутствие оставшихся `password=` в тестах

https://claude.ai/code/session_01DpSqhfXWJBAQuWtrYgHFEo