### PR TITLE
fix(deploy): pass SOCKS5_PROXY_URL to Docker containers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,4 +83,4 @@ pytest + pytest-django. Config in `pyproject.toml` sets `DJANGO_SETTINGS_MODULE 
 
 GitHub Actions: lint+test on push/PR to master → build Docker image to ghcr.io → deploy to VDS via SSH + docker-compose.
 
-When adding, removing, or renaming environment variables, update the deploy workflow (`.github/workflows/`) — env vars are passed explicitly to containers in the deploy step.
+When adding, removing, or renaming environment variables, update **both** the deploy workflow (`.github/workflows/`) and the `environment` sections in `docker-compose.prod.yml` (`web` and `bot` services) — env vars are passed explicitly to containers in both places. The `.env` file on the host is NOT mounted into containers; variables reach Django only through docker-compose `environment`.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -34,6 +34,7 @@ services:
       GLITCHTIP_RELEASE: ${GLITCHTIP_RELEASE:-}
       LOGTIDE_API_URL: ${LOGTIDE_API_URL:-}
       LOGTIDE_API_KEY: ${LOGTIDE_API_KEY:-}
+      SOCKS5_PROXY_URL: ${SOCKS5_PROXY_URL}
       LOGTIDE_SERVICE_NAME: food-purchase-planner-web
     volumes:
       - static_volume:/app/staticfiles
@@ -60,6 +61,7 @@ services:
       GLITCHTIP_RELEASE: ${GLITCHTIP_RELEASE:-}
       LOGTIDE_API_URL: ${LOGTIDE_API_URL:-}
       LOGTIDE_API_KEY: ${LOGTIDE_API_KEY:-}
+      SOCKS5_PROXY_URL: ${SOCKS5_PROXY_URL}
       LOGTIDE_SERVICE_NAME: food-purchase-planner-bot
     depends_on:
       db:


### PR DESCRIPTION
## Summary
- Добавлена переменная `SOCKS5_PROXY_URL` в секции `environment` сервисов `web` и `bot` в `docker-compose.prod.yml`
- Уточнена документация в `CLAUDE.md`: при добавлении env vars нужно обновлять и workflow, и docker-compose

## Причина
После деплоя #43 контейнеры падали с `KeyError: 'SOCKS5_PROXY_URL'` на `manage.py migrate`. Переменная была в `.env` на хосте и в GitHub secrets, но не пробрасывалась в контейнеры через docker-compose.